### PR TITLE
Allow locally renaming the timer

### DIFF
--- a/src/webview/scripts/components/TopBar.tsx
+++ b/src/webview/scripts/components/TopBar.tsx
@@ -1,60 +1,122 @@
-import { ActionIcon, Group, Menu, Title } from "@mantine/core";
+import { ActionIcon, Menu, TextInput, Tooltip, Text, Grid } from "@mantine/core";
 import { IconBrandGithub, IconBrandVscode, IconMenu2, IconMoonStars, IconSun, IconVersions } from "@tabler/icons-react";
 import { displayName, repository } from "../../../../package.json";
 import { isRunningInBrowser } from "../constants/booleans";
 import { changelogUrl, vsCodeMarketplaceUrl } from "../constants/strings";
 import { useColorSchemeFromLocalStorage } from "./hooks/useColorSchemeFromLocalStorage";
+import { CSSProperties, useState } from "react";
 
 export function TopBar() {
   const [colorScheme, toggleColorScheme] = useColorSchemeFromLocalStorage();
 
   return (
-    <Group position="apart">
-      <Title order={3}>{displayName}</Title>
-      <Menu withinPortal position="bottom-end" shadow="sm">
-        <Menu.Target>
-          <ActionIcon>
-            <IconMenu2 size={24} />
-          </ActionIcon>
-        </Menu.Target>
-        <Menu.Dropdown>
-          <Menu.Item
-            icon={colorScheme === "dark" ? <IconSun size={14} /> : <IconMoonStars size={14} />}
-            onClick={() => toggleColorScheme()}
-          >
-            {colorScheme === "dark" ? "Light" : "Dark"} mode
-          </Menu.Item>
-          {isRunningInBrowser && (
+    <Grid align="center" justify="space-between">
+      <Grid.Col span={10}>
+        <EditableTimerName fontSize="1.375rem" fontWeight="bold" lineHeight="1.65" height="36px" />
+      </Grid.Col>
+      <Grid.Col span="content">
+        <Menu withinPortal position="bottom-end" shadow="sm">
+          <Menu.Target>
+            <ActionIcon>
+              <IconMenu2 size={24} />
+            </ActionIcon>
+          </Menu.Target>
+          <Menu.Dropdown>
             <Menu.Item
-              icon={<IconBrandVscode size={14} />}
+              icon={colorScheme === "dark" ? <IconSun size={14} /> : <IconMoonStars size={14} />}
+              onClick={() => toggleColorScheme()}
+            >
+              {colorScheme === "dark" ? "Light" : "Dark"} mode
+            </Menu.Item>
+            {isRunningInBrowser && (
+              <Menu.Item
+                icon={<IconBrandVscode size={14} />}
+                component="a"
+                target="_blank"
+                rel="noopener noreferrer"
+                href={vsCodeMarketplaceUrl}
+              >
+                VS Code extension
+              </Menu.Item>
+            )}
+            <Menu.Item
+              icon={<IconBrandGithub size={14} />}
               component="a"
               target="_blank"
               rel="noopener noreferrer"
-              href={vsCodeMarketplaceUrl}
+              href={repository.url}
             >
-              VS Code extension
+              Source code
             </Menu.Item>
-          )}
-          <Menu.Item
-            icon={<IconBrandGithub size={14} />}
-            component="a"
-            target="_blank"
-            rel="noopener noreferrer"
-            href={repository.url}
-          >
-            Source code
-          </Menu.Item>
-          <Menu.Item
-            icon={<IconVersions size={14} />}
-            component="a"
-            target="_blank"
-            rel="noopener noreferrer"
-            href={changelogUrl}
-          >
-            Changelog
-          </Menu.Item>
-        </Menu.Dropdown>
-      </Menu>
-    </Group>
+            <Menu.Item
+              icon={<IconVersions size={14} />}
+              component="a"
+              target="_blank"
+              rel="noopener noreferrer"
+              href={changelogUrl}
+            >
+              Changelog
+            </Menu.Item>
+          </Menu.Dropdown>
+        </Menu>
+      </Grid.Col>
+    </Grid>
+  );
+}
+
+function EditableTimerName({
+  fontSize,
+  fontWeight,
+  lineHeight,
+  height,
+}: {
+  fontSize: CSSProperties["fontSize"];
+  fontWeight: CSSProperties["fontWeight"];
+  lineHeight: CSSProperties["lineHeight"];
+  height: CSSProperties["height"];
+}) {
+  const [isEditing, setEditing] = useState(false);
+  const [currentText, setText] = useState(displayName);
+
+  const submit = () => {
+    const newText = currentText.trim();
+    setText(newText.length > 0 ? newText : displayName);
+    setEditing(false);
+  };
+
+  return isEditing ? (
+    <TextInput
+      placeholder={displayName}
+      value={currentText}
+      autoFocus
+      variant="unstyled"
+      styles={{
+        input: {
+          padding: "0",
+          // @ts-expect-error - Types don't match.
+          fontWeight,
+          fontSize,
+          lineHeight,
+          height,
+        },
+      }}
+      onChange={({ currentTarget }) => setText(currentTarget.value)}
+      onBlur={submit}
+      onKeyDown={(event) => {
+        if (event.key === "Enter") submit();
+      }}
+    />
+  ) : (
+    <Tooltip
+      label={"Click to rename this timer"}
+      color="blue"
+      position="bottom-start"
+      withArrow
+      transitionProps={{ transition: "pop", duration: 300 }}
+    >
+      <Text size={fontSize} fw={fontWeight} lh={lineHeight} h={height} onClick={() => setEditing(true)} truncate>
+        {currentText}
+      </Text>
+    </Tooltip>
   );
 }


### PR DESCRIPTION
## Description

As suggested by @nitsanavni: 
- https://github.com/felladrin/LinkedTimer/discussions/19

This PR allows users to rename their timers locally, so they can differentiate them when several are opened.

| Hovering the name | Renaming |
|--------|--------|
| <img width="361" alt="image" src="https://github.com/felladrin/LinkedTimer/assets/418083/65f31ba6-344d-4bd1-9a0b-489e9e409e27"> | <img width="350" alt="image" src="https://github.com/felladrin/LinkedTimer/assets/418083/adcfa4e8-f10c-40e9-95e8-c2687704444f"> |

## Notes

It doesn't synchronize the name with other users. It still needs to be discussed, as there are some cons to it.

If the name is too long, it will show an ellipsis.

| Too-long name |
|--------|
| <img width="345" alt="image" src="https://github.com/felladrin/LinkedTimer/assets/418083/ddad4294-767d-40de-9dcd-2d2c6eff7543"> | 


